### PR TITLE
Bumps version and removes deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ which will be closed after use by FS2:
 This takes a string representing a MongoDB URL (e.g. `mongodb://localhost`).
 
 *`Mongo.fromSettings[F]`*
-This takes a `com.mongodb.async.client.MongoClientSettings` object, and uses to set
+This takes a `com.mongodb.MongoClientSettings` object, and uses to set
 up the client (this can include connecting to multiple databases, required authentication
 information, etc.).
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ organization := "org.lyranthe"
 
 name := "fs2-mongodb"
 
-libraryDependencies += "org.mongodb" % "mongodb-driver-async" % "3.6.3"
-libraryDependencies += "co.fs2"      %% "fs2-core"            % "0.10.2"
+libraryDependencies += "org.mongodb" % "mongodb-driver-async" % "3.8.0"
+libraryDependencies += "co.fs2"      %% "fs2-core"            % "0.10.5"
 
 enablePlugins(GitVersioning)
 

--- a/src/main/scala/org/lyranthe/fs2_mongodb/MongoClient.scala
+++ b/src/main/scala/org/lyranthe/fs2_mongodb/MongoClient.scala
@@ -1,6 +1,8 @@
 package org.lyranthe.fs2_mongodb
 
-import com.mongodb.async.client.{MongoClient, MongoClientSettings, MongoClients}
+import com.mongodb.async.client.{MongoClient, MongoClients}
+import com.mongodb.MongoClientSettings
+
 import fs2._
 import cats.effect.Sync
 
@@ -10,9 +12,8 @@ object Mongo {
       F.delay(client.close())
     })
   }
-
   def fromSettings[F[_]](settings: MongoClientSettings)(
-      implicit F: Sync[F]): Stream[F, MongoClient] = {
+    implicit F: Sync[F]): Stream[F, MongoClient] = {
     Stream.bracket(F.delay(MongoClients.create(settings)))(Stream.emit(_), { client =>
       F.delay(client.close())
     })

--- a/src/main/scala/org/lyranthe/fs2_mongodb/imports.scala
+++ b/src/main/scala/org/lyranthe/fs2_mongodb/imports.scala
@@ -106,7 +106,7 @@ class MongoCollectionEffect[F[_], A](val underlying: MongoCollection[A]) extends
   def count(implicit F: Async[F]): F[Long] = {
     Async[F]
       .async[java.lang.Long] { cb =>
-        underlying.count(cb.toMongo)
+        underlying.countDocuments(cb.toMongo)
       }
       .map(_.longValue())
   }
@@ -114,7 +114,7 @@ class MongoCollectionEffect[F[_], A](val underlying: MongoCollection[A]) extends
   def count(filter: Bson)(implicit F: Async[F]): F[Long] = {
     Async[F]
       .async[java.lang.Long] { cb =>
-        underlying.count(filter, cb.toMongo)
+        underlying.countDocuments(filter, cb.toMongo)
       }
       .map(_.longValue())
   }


### PR DESCRIPTION
This PR updates the `mongodb` driver version and `fs2-core`.

Apart from that, I changed two methods  due to MongoClientSettings is `deprecated` in `com.mongodb.async.client`

After this PR, we should bump the version to `0.3.0`. What do you think @fiadliel?

Please, let me know if you have any doubt